### PR TITLE
Add webhook server tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "eslint-plugin-prettier": "^5.5.1",
         "jest": "^30.0.3",
         "nodemon": "^3.0.2",
-        "prettier": "^3.1.1"
+        "prettier": "^3.1.1",
+        "supertest": "^6.3.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -3421,6 +3422,16 @@
         "@octokit/openapi-types": "^24.2.0"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4277,10 +4288,24 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-jest": {
@@ -4991,6 +5016,19 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -4998,6 +5036,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concat-map": {
@@ -5048,6 +5096,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
@@ -5152,6 +5207,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5185,6 +5250,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/doctrine": {
@@ -5322,6 +5398,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5911,6 +6003,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -6069,6 +6168,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -6292,6 +6424,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -9794,6 +9942,57 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-prettier": "^5.5.1",
     "jest": "^30.0.3",
     "nodemon": "^3.0.2",
-    "prettier": "^3.1.1"
+    "prettier": "^3.1.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/tests/webhooks/webhook-handlers.test.js
+++ b/tests/webhooks/webhook-handlers.test.js
@@ -1,0 +1,68 @@
+import request from 'supertest';
+
+jest.mock('chalk', () => ({
+  blue: jest.fn(t => t),
+  cyan: jest.fn(t => t),
+  green: jest.fn(t => t),
+  yellow: jest.fn(t => t),
+  magenta: jest.fn(t => t),
+  red: jest.fn(t => t),
+  gray: jest.fn(t => t),
+}));
+
+describe('Webhook server handlers', () => {
+  let app;
+
+  beforeAll(async () => {
+    ({ app } = await import('../../webhooks/webhook-server.js'));
+  });
+
+  test('responds to push event', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const payload = {
+      repository: { full_name: 'user/repo' },
+      pusher: { name: 'Alice', email: 'alice@example.com' },
+      commits: [{ message: 'init', author: { name: 'Alice' } }],
+      ref: 'refs/heads/main',
+    };
+
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-GitHub-Event', 'push')
+      .set('X-GitHub-Delivery', '1')
+      .set('Content-Type', 'application/json')
+      .send(JSON.stringify(payload));
+
+    expect(res.status).toBe(200);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('📤 Push Event Recebido')
+    );
+
+    logSpy.mockRestore();
+  });
+
+  test('responds to issues event', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const payload = {
+      action: 'opened',
+      issue: { number: 1, title: 'Issue', user: { login: 'bob' } },
+      repository: { full_name: 'user/repo' },
+    };
+
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-GitHub-Event', 'issues')
+      .set('X-GitHub-Delivery', '2')
+      .set('Content-Type', 'application/json')
+      .send(JSON.stringify(payload));
+
+    expect(res.status).toBe(200);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('🐛 Issues Event Recebido')
+    );
+
+    logSpy.mockRestore();
+  });
+});

--- a/webhooks/webhook-server.js
+++ b/webhooks/webhook-server.js
@@ -181,23 +181,55 @@ app.get('/health', (req, res) => {
 /**
  * Iniciar servidor
  */
-app.listen(PORT, () => {
-  console.log(chalk.green(`🎣 Webhook server rodando na porta ${PORT}`));
-  console.log(chalk.cyan(`📝 Status: http://localhost:${PORT}/status`));
-  console.log(chalk.cyan(`💚 Health: http://localhost:${PORT}/health`));
-  console.log(chalk.cyan(`🎯 Webhook: http://localhost:${PORT}/webhook`));
+function startServer(port = PORT) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(port, () => {
+      console.log(chalk.green(`🎣 Webhook server rodando na porta ${port}`));
+      console.log(chalk.cyan(`📝 Status: http://localhost:${port}/status`));
+      console.log(chalk.cyan(`💚 Health: http://localhost:${port}/health`));
+      console.log(chalk.cyan(`🎯 Webhook: http://localhost:${port}/webhook`));
 
-  if (!WEBHOOK_SECRET) {
-    console.log(
-      chalk.yellow(
-        '\n⚠️  Configure WEBHOOK_SECRET no arquivo .env para maior segurança'
-      )
-    );
-  }
+      if (!WEBHOOK_SECRET) {
+        console.log(
+          chalk.yellow(
+            '\n⚠️  Configure WEBHOOK_SECRET no arquivo .env para maior segurança'
+          )
+        );
+      }
 
-  console.log(chalk.blue('\n📖 Para configurar no GitHub:'));
-  console.log(chalk.gray('   1. Vá em Settings > Webhooks no seu repositório'));
-  console.log(chalk.gray(`   2. Adicione URL: http://localhost:${PORT}/webhook`));
-  console.log(chalk.gray('   3. Selecione eventos desejados'));
-  console.log(chalk.gray('   4. Configure o secret (se disponível)'));
-});
+      console.log(chalk.blue('\n📖 Para configurar no GitHub:'));
+      console.log(
+        chalk.gray('   1. Vá em Settings > Webhooks no seu repositório')
+      );
+      console.log(
+        chalk.gray(`   2. Adicione URL: http://localhost:${port}/webhook`)
+      );
+      console.log(chalk.gray('   3. Selecione eventos desejados'));
+      console.log(chalk.gray('   4. Configure o secret (se disponível)'));
+      resolve(server);
+    });
+
+    server.on('error', error => {
+      console.error(
+        chalk.red(`Erro ao iniciar webhook server: ${error.message}`)
+      );
+      reject(error);
+    });
+  });
+}
+
+// Executar o servidor se este arquivo for executado diretamente
+if (process.argv[1] && process.argv[1].includes('webhook-server.js')) {
+  startServer();
+}
+
+export {
+  app,
+  startServer,
+  handlePushEvent,
+  handleIssuesEvent,
+  handlePullRequestEvent,
+  handleReleaseEvent,
+  handleStarEvent,
+  verifyGitHubSignature,
+};


### PR DESCRIPTION
## Summary
- export webhook server handlers and startServer helper
- add Supertest dev dependency
- test webhook push and issue events

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e4d781eac8330acc2b0a56232a78f