### PR TITLE
Add simple REST and homepage servers

### DIFF
--- a/api/simple-rest-server.js
+++ b/api/simple-rest-server.js
@@ -1,0 +1,12 @@
+import express from 'express';
+
+const app = express();
+const PORT = process.env.API_PORT || 3001;
+
+app.get('/api/status', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Simple REST server running on port ${PORT}`);
+});

--- a/serve-homepage.js
+++ b/serve-homepage.js
@@ -1,0 +1,19 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const app = express();
+const PORT = process.env.PORT || 8080;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+app.use(express.static(__dirname));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Homepage server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a minimal Express REST server
- add a minimal homepage server to serve index.html
- ensure package.json scripts refer to these servers

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e4d63bcc083308f50ea5ecd869ca0